### PR TITLE
Added get_numdigits function

### DIFF
--- a/examples/color_wheel/color_wheel.ino
+++ b/examples/color_wheel/color_wheel.ino
@@ -17,6 +17,10 @@ void loop() {
     hue+=32;                        // Push hue 1/8th through the color wheel
     lix.color_on_hsv(hue,255,255);  // Set new color
   }
+
+  if(count >= pow(10,lix.get_numdigits())){ // If count > number that can be displayed
+    count = 0;
+  }
   
   delay(100);
 }

--- a/keywords.txt
+++ b/keywords.txt
@@ -18,6 +18,7 @@ write_digit	KEYWORD2
 write_char	KEYWORD2
 show	KEYWORD2
 print_binary	KEYWORD2
+get_numdigits	KEYWORD2
 color_on_rgb	KEYWORD2
 color_off_rgb	KEYWORD2
 color_on_hsv	KEYWORD2

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -300,3 +300,8 @@ void Lixie::print_binary() {
   }
   Serial.println();
 }
+
+uint8_t Lixie::get_numdigits() const{
+  return NUM_DIGITS;
+}
+

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -28,6 +28,7 @@ class Lixie
 
 	void show();
 	void print_binary();
+  uint8_t get_numdigits() const;
 	
 	void color_on_rgb(byte r, byte g, byte b);
 	void color_on_hsv(byte h, byte s, byte v);


### PR DESCRIPTION
I thought it would be useful to have a simple function which returned the number of digits (for limiting output variables and the like). With the new function I also added a line to the example sketch so it rolls over when reaching the max displayable value.