### PR TITLE
Explicitly defined private functions as class members

### DIFF
--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -17,11 +17,11 @@ CRGB colors_off[NUM_DIGITS];
 
 Lixie::Lixie(){}
 
-void setBit(uint16_t pos, byte val){
+void Lixie::setBit(uint16_t pos, byte val){
 	bitWrite(led_states[(pos/8)], pos % 8, val);
 }
 
-byte getBit(uint16_t pos){
+byte Lixie::getBit(uint16_t pos){
 	return bitRead(led_states[(pos/8)], pos % 8);
 }
 
@@ -114,7 +114,7 @@ void Lixie::color_off(CRGB c, byte index){
 	colors_off[index] = c;
 }
 
-byte get_size(uint32_t input){
+byte Lixie::get_size(uint32_t input){
 	byte places = 0;
 	while(input > 0){
 		places++;
@@ -123,11 +123,11 @@ byte get_size(uint32_t input){
 	return places;
 }
 
-byte char_to_number(char input){
+byte Lixie::char_to_number(char input){
 	return byte(input-48); // convert ascii index to real number
 }
 
-bool char_is_number(char input){
+bool Lixie::char_is_number(char input){
 	if(input <= 57 && input >= 48) // if between ASCII '9' and '0'
 		return true;
 	else

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -21,7 +21,7 @@ void Lixie::setBit(uint16_t pos, byte val){
 	bitWrite(led_states[(pos/8)], pos % 8, val);
 }
 
-byte Lixie::getBit(uint16_t pos){
+byte Lixie::getBit(uint16_t pos) const{
 	return bitRead(led_states[(pos/8)], pos % 8);
 }
 
@@ -114,7 +114,7 @@ void Lixie::color_off(CRGB c, byte index){
 	colors_off[index] = c;
 }
 
-byte Lixie::get_size(uint32_t input){
+byte Lixie::get_size(uint32_t input) const{
 	byte places = 0;
 	while(input > 0){
 		places++;
@@ -123,11 +123,11 @@ byte Lixie::get_size(uint32_t input){
 	return places;
 }
 
-byte Lixie::char_to_number(char input){
+byte Lixie::char_to_number(char input) const{
 	return byte(input-48); // convert ascii index to real number
 }
 
-bool Lixie::char_is_number(char input){
+bool Lixie::char_is_number(char input) const{
 	if(input <= 57 && input >= 48) // if between ASCII '9' and '0'
 		return true;
 	else

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -45,6 +45,12 @@ class Lixie{
 
 		void color_off(byte r, byte g, byte b, byte index);
 		void color_off(CRGB c, byte index);
+	private:
+		void setBit(uint16_t pos, byte val);
+		byte getBit(uint16_t pos);
+		byte get_size(uint32_t input);
+		byte char_to_number(char input);
+		bool char_is_number(char input);
 };
 
 #endif

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -47,10 +47,10 @@ class Lixie{
 		void color_off(CRGB c, byte index);
 	private:
 		void setBit(uint16_t pos, byte val);
-		byte getBit(uint16_t pos);
-		byte get_size(uint32_t input);
-		byte char_to_number(char input);
-		bool char_is_number(char input);
+		byte getBit(uint16_t pos) const;
+		byte get_size(uint32_t input) const;
+		byte char_to_number(char input) const;
+		bool char_is_number(char input) const;
 };
 
 #endif


### PR DESCRIPTION
Five of the functions used inside of the class were not members of the class itself:

- setBit
- getBit
- get_size
- char_to_number
- char_is_number

I included these as private functions and added const modifiers where appropriate. This should prevent problems with conflicting function definitions in other files.