### PR TITLE
Fixed NUM_LEDS length

### DIFF
--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -7,10 +7,10 @@ Released under the GPLv3 license.
 #include "Lixie.h"
 #include "config.h"
 
-#define NUM_LEDS NUM_DIGITS * 24
+#define NUM_LEDS NUM_DIGITS * 20
 CRGB leds[NUM_LEDS];
 
-byte led_states[NUM_LEDS/8];
+byte led_states[NUM_DIGITS*3];
 byte addresses[10] = {3, 4, 2, 0, 8, 6, 5, 7, 9, 1};
 CRGB colors[NUM_DIGITS];
 CRGB colors_off[NUM_DIGITS];


### PR DESCRIPTION
I changed the number of LEDs to "20" rather than "24", and I updated the calculation for the led_states array according to always use 3 bytes per digit.

At first I thought this was a typo, but then I realized that you probably did this so there were enough bits to store all of the LED 'show' information. Regardless, it leads to some weird bugs when pushing the data to a strip longer than intended (e.g. driving two Lixies when the code is only set to one). You'll have to test on the Lixies themselves, but it seems to work as-intended on my LED strip.