### PR TITLE
Color Balance and Brightness Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This library allows for easy writing to Lixie digit displays! It takes care of a
 # Contents
 - [Installation](#installation)
 - [Getting Started](#getting-started)
-- [Functions](#functions)
+- [Basic Functions](#basic-functions)
+- [Additional Functions](#additional-functions)
 - [Contributing](#contributing)
 - [License and credits](#license-and-credits)
 
@@ -50,7 +51,7 @@ This library allows for easy writing to Lixie digit displays! It takes care of a
     }
 
 ----------
-# Functions
+# Basic Functions
 
 **lix.begin**();
 
@@ -73,6 +74,21 @@ Sets the "on" color of the digits using RGB. This is the color of an active numb
 **lix.color_off**(byte **r**, byte **g**, byte **b**);
 
 Sets the "off" color of the digits using RGB. This is the color of all inactive numbers in the display. (Default: 0,0,0)
+
+----------
+# Additional Functions
+
+**lix.get_numdigits**();
+
+Returns the number of Lixie displays currently in use.
+
+**lix.brightness**(byte **bright**);
+
+Sets the brightness of the displays, from 0 - 255. (Default: 255)
+
+**lix.color_balance**(CRGB **c_adj**);
+
+Sets a color calibration for the LEDs. Supports all FastLED color temperatures, and custom temperatures in the form CRGB(r, g, b). (Default: Tungsten100W / R: 255 G: 214 B: 170)
 
 ----------
 # Contributing

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,36 @@
 # LIXIE for ARDUINO CHANGE LOG:
 (Most recent at top, please!)
 
+Added brightness control (1/5/17 - dmadison)
+-----------------------------------------------------------
+
+With the instance-specific FastLED controllers set up, now seemed like the perfect time to implement brightness control. Brightness control is isolated per-instance, so you can adjust the brightness of each Lixie group independently. You can adjust brightness by calling:
+
+    brightness(255);
+
+Where the parameter is an integer between 0 - 255.
+
+Changed color balance functions to use FastLED (1/5/17 - dmadison)
+-----------------------------------------------------------
+
+I rewrote the color balance functionality so that it uses FastLED's color temperature implementation and CRGB objects. This has a number of benefits:
+
+- It's faster: the calibration math is done during the FastLED show() call, and I believe it's also done between bit-bang clock cycles. This mean's adjusting calibration on the fly is quicker.
+- It's nondestructive: colors in the color-setting arrays are not changed, which makes gradual color changes easier.
+- It's cleaner: I like pretty code.
+
+Created instance-specific FastLED controller (1/5/17 - dmadison)
+-----------------------------------------------------------
+
+Each instance now has its own FastLED controller, so things like brightness control, color balance, and show() calls can be isolated to specific displays rather than driven globally.
+
+
+Added array bounds check to color setting by index (1/5/17 - dmadison)
+-----------------------------------------------------------
+
+The color setting functions that allow the user to set a color for a specific digit now check to see if the digit exists before writing to the array. This should prevent memory addressing problems.
+
+
 Removed 'config.h' and added support for multiple instances (1/4/17)
 -----------------------------------------------------------
 

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -10,7 +10,6 @@ Released under the GPLv3 license.
 #define COLOR_ORDER GRB
 
 static constexpr byte Lixie::addresses[];
-float color_bal[3] = {1.00, 0.90, 0.65};
 
 Lixie::Lixie(uint8_t pin, uint8_t nDigits):NumDigits(nDigits), NumLEDs(nDigits * 20){
 	leds = new CRGB[NumLEDs];
@@ -36,6 +35,7 @@ void Lixie::begin() {
 		colors[i] = CRGB(255,255,255);
 		colors_off[i] = CRGB(0,0,0);
 	}
+	color_balance(Tungsten100W);
 	clear();
 }
 
@@ -69,68 +69,60 @@ void Lixie::show(){
 // set all on color ------------------------------------
 void Lixie::color(byte r, byte g, byte b){
 	for(byte i = 0; i < NumDigits; i++){
-		colors[i].r = r*color_bal[0];
-		colors[i].g = g*color_bal[1];
-		colors[i].b = b*color_bal[2];
+		colors[i].r = r;
+		colors[i].g = g;
+		colors[i].b = b;
 	}
 }
 
 void Lixie::color(CRGB c){
 	for(byte i = 0; i < NumDigits; i++){
-		colors[i].r = c.r*color_bal[0];
-		colors[i].g = c.g*color_bal[1];
-		colors[i].b = c.b*color_bal[2];
+		colors[i] = c;
 	}
 }
 
 // set index on color ------------------------------------
 void Lixie::color(byte r, byte g, byte b, byte index){
 	if(index < NumDigits){
-		colors[index].r = r*color_bal[0];
-		colors[index].g = g*color_bal[1];
-		colors[index].b = b*color_bal[2];
+		colors[index].r = r;
+		colors[index].g = g;
+		colors[index].b = b;
 	}
 }
 
 void Lixie::color(CRGB c, byte index){
 	if(index < NumDigits){
-		colors[index].r = c.r*color_bal[0];
-		colors[index].g = c.g*color_bal[1];
-		colors[index].b = c.b*color_bal[2];
+		colors[index] = c;
 	}
 }
 
 // set all off color -------------------------------------
 void Lixie::color_off(byte r, byte g, byte b){
 	for(byte i = 0; i < NumDigits; i++){
-		colors_off[i].r = r*color_bal[0];
-		colors_off[i].g = g*color_bal[1];
-		colors_off[i].b = b*color_bal[2];
+		colors_off[i].r = r;
+		colors_off[i].g = g;
+		colors_off[i].b = b;
 	}
 }
 
 void Lixie::color_off(CRGB c){
 	for(byte i = 0; i < NumDigits; i++){
-		colors_off[i].r = c.r*color_bal[0];
-		colors_off[i].g = c.g*color_bal[1];
-		colors_off[i].b = c.b*color_bal[2];
+		colors_off[i] = c;
 	}
 }
 
 // set index color off -----------------------------------
 void Lixie::color_off(byte r, byte g, byte b, byte index){
 	if(index < NumDigits){
-		colors_off[index].r = r*color_bal[0];
-		colors_off[index].g = g*color_bal[1];
-		colors_off[index].b = b*color_bal[2];
+		colors_off[index].r = r;
+		colors_off[index].g = g;
+		colors_off[index].b = b;
 	}
 }
 
 void Lixie::color_off(CRGB c, byte index){
 	if(index < NumDigits){
-		colors_off[index].r = c.r*color_bal[0];
-		colors_off[index].g = c.g*color_bal[1];
-		colors_off[index].b = c.b*color_bal[2];
+		colors_off[index] = c;
 	}
 }
 
@@ -317,8 +309,6 @@ void Lixie::max_power(byte volts, uint16_t milliamps){
 	FastLED.setMaxPowerInVoltsAndMilliamps(volts,milliamps); 
 }
 
-void Lixie::color_balance(float r_adj,float g_adj,float b_adj){
-	color_bal[0] = r_adj;
-	color_bal[1] = g_adj;
-	color_bal[2] = b_adj;
+void Lixie::color_balance(CRGB c_adj){
+	controller->setTemperature(c_adj);
 }

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -63,7 +63,7 @@ void Lixie::show(){
 			leds[i] = CRGB(r,g,b);
 		}
 	}
-	controller->showLeds();
+	controller->showLeds(bright);
 }
 
 // set all on color ------------------------------------
@@ -312,3 +312,8 @@ void Lixie::max_power(byte volts, uint16_t milliamps){
 void Lixie::color_balance(CRGB c_adj){
 	controller->setTemperature(c_adj);
 }
+
+void Lixie::brightness(byte newBright){
+	bright = newBright;
+}
+

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -30,7 +30,7 @@ byte Lixie::getBit(uint16_t pos) const{
 }
 
 void Lixie::begin() {
-	FastLED.show();
+	controller->showLeds();
   max_power(5,1000);
 	for(byte i = 0; i < NumDigits; i++){
 		colors[i] = CRGB(255,255,255);
@@ -63,7 +63,7 @@ void Lixie::show(){
 			leds[i] = CRGB(r,g,b);
 		}
 	}
-	FastLED.show();
+	controller->showLeds();
 }
 
 // set all on color ------------------------------------
@@ -269,46 +269,46 @@ bool Lixie::maxed_out(float input){
 void Lixie::build_controller(uint8_t DataPin){
 	switch (DataPin){
 		case 0:
-			FastLED.addLeds<LED_TYPE, 0, COLOR_ORDER>(leds, NumLEDs);
+			controller = &FastLED.addLeds<LED_TYPE, 0, COLOR_ORDER>(leds, NumLEDs);
 			break;
 		case 1:
-			FastLED.addLeds<LED_TYPE, 1, COLOR_ORDER>(leds, NumLEDs);
+			controller = &FastLED.addLeds<LED_TYPE, 1, COLOR_ORDER>(leds, NumLEDs);
 			break;
 		case 2:
-			FastLED.addLeds<LED_TYPE, 2, COLOR_ORDER>(leds, NumLEDs);
+			controller = &FastLED.addLeds<LED_TYPE, 2, COLOR_ORDER>(leds, NumLEDs);
 			break;
 		case 3:
-			FastLED.addLeds<LED_TYPE, 3, COLOR_ORDER>(leds, NumLEDs);
+			controller = &FastLED.addLeds<LED_TYPE, 3, COLOR_ORDER>(leds, NumLEDs);
 			break;
 		case 4:
-			FastLED.addLeds<LED_TYPE, 4, COLOR_ORDER>(leds, NumLEDs);
+			controller = &FastLED.addLeds<LED_TYPE, 4, COLOR_ORDER>(leds, NumLEDs);
 			break;
 		case 5:
-			FastLED.addLeds<LED_TYPE, 5, COLOR_ORDER>(leds, NumLEDs);
+			controller = &FastLED.addLeds<LED_TYPE, 5, COLOR_ORDER>(leds, NumLEDs);
 			break;
 		case 6:
-			FastLED.addLeds<LED_TYPE, 6, COLOR_ORDER>(leds, NumLEDs);
+			controller = &FastLED.addLeds<LED_TYPE, 6, COLOR_ORDER>(leds, NumLEDs);
 			break;
 		case 7:
-			FastLED.addLeds<LED_TYPE, 7, COLOR_ORDER>(leds, NumLEDs);
+			controller = &FastLED.addLeds<LED_TYPE, 7, COLOR_ORDER>(leds, NumLEDs);
 			break;
 		case 8:
-			FastLED.addLeds<LED_TYPE, 8, COLOR_ORDER>(leds, NumLEDs);
+			controller = &FastLED.addLeds<LED_TYPE, 8, COLOR_ORDER>(leds, NumLEDs);
 			break;
 		case 9:
-			FastLED.addLeds<LED_TYPE, 9, COLOR_ORDER>(leds, NumLEDs);
+			controller = &FastLED.addLeds<LED_TYPE, 9, COLOR_ORDER>(leds, NumLEDs);
 			break;
 		case 10:
-			FastLED.addLeds<LED_TYPE, 10, COLOR_ORDER>(leds, NumLEDs);
+			controller = &FastLED.addLeds<LED_TYPE, 10, COLOR_ORDER>(leds, NumLEDs);
 			break;
 		case 11:
-			FastLED.addLeds<LED_TYPE, 11, COLOR_ORDER>(leds, NumLEDs);
+			controller = &FastLED.addLeds<LED_TYPE, 11, COLOR_ORDER>(leds, NumLEDs);
 			break;
 		case 12:
-			FastLED.addLeds<LED_TYPE, 12, COLOR_ORDER>(leds, NumLEDs);
+			controller = &FastLED.addLeds<LED_TYPE, 12, COLOR_ORDER>(leds, NumLEDs);
 			break;
 		case 13:
-			FastLED.addLeds<LED_TYPE, 13, COLOR_ORDER>(leds, NumLEDs);
+			controller = &FastLED.addLeds<LED_TYPE, 13, COLOR_ORDER>(leds, NumLEDs);
 			break;
 	}
 }

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -85,15 +85,19 @@ void Lixie::color(CRGB c){
 
 // set index on color ------------------------------------
 void Lixie::color(byte r, byte g, byte b, byte index){
-	colors[index].r = r*color_bal[0];
-	colors[index].g = g*color_bal[1];
-	colors[index].b = b*color_bal[2];
+	if(index < NumDigits){
+		colors[index].r = r*color_bal[0];
+		colors[index].g = g*color_bal[1];
+		colors[index].b = b*color_bal[2];
+	}
 }
 
 void Lixie::color(CRGB c, byte index){
-	colors[index].r = c.r*color_bal[0];
-	colors[index].g = c.g*color_bal[1];
-	colors[index].b = c.b*color_bal[2];
+	if(index < NumDigits){
+		colors[index].r = c.r*color_bal[0];
+		colors[index].g = c.g*color_bal[1];
+		colors[index].b = c.b*color_bal[2];
+	}
 }
 
 // set all off color -------------------------------------
@@ -115,15 +119,19 @@ void Lixie::color_off(CRGB c){
 
 // set index color off -----------------------------------
 void Lixie::color_off(byte r, byte g, byte b, byte index){
-	colors_off[index].r = r*color_bal[0];
-	colors_off[index].g = g*color_bal[1];
-	colors_off[index].b = b*color_bal[2];
+	if(index < NumDigits){
+		colors_off[index].r = r*color_bal[0];
+		colors_off[index].g = g*color_bal[1];
+		colors_off[index].b = b*color_bal[2];
+	}
 }
 
 void Lixie::color_off(CRGB c, byte index){
-	colors_off[index].r = c.r*color_bal[0];
-	colors_off[index].g = c.g*color_bal[1];
-	colors_off[index].b = c.b*color_bal[2];
+	if(index < NumDigits){
+		colors_off[index].r = c.r*color_bal[0];
+		colors_off[index].g = c.g*color_bal[1];
+		colors_off[index].b = c.b*color_bal[2];
+	}
 }
 
 byte Lixie::get_size(uint32_t input) const{

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -48,7 +48,7 @@ class Lixie{
 		void color_off(byte r, byte g, byte b, byte index);
 		void color_off(CRGB c, byte index);
 		
-		void color_balance(float r_adj,float g_adj,float b_adj);
+		void color_balance(CRGB c_adj);
 
 	private:
 		static constexpr byte addresses[10] = {3, 4, 2, 0, 8, 6, 5, 7, 9, 1};

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -49,6 +49,7 @@ class Lixie{
 		void color_off(CRGB c, byte index);
 		
 		void color_balance(CRGB c_adj);
+		void brightness(byte bright);
 
 	private:
 		static constexpr byte addresses[10] = {3, 4, 2, 0, 8, 6, 5, 7, 9, 1};
@@ -59,6 +60,7 @@ class Lixie{
 		CRGB *colors_off;
 		byte *led_states;
 		CLEDController *controller;
+		byte bright = 255;
 		void setBit(uint16_t pos, byte val);
 		byte getBit(uint16_t pos) const;
 		byte get_size(uint32_t input) const;

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -58,6 +58,7 @@ class Lixie{
 		CRGB *colors;
 		CRGB *colors_off;
 		byte *led_states;
+		CLEDController *controller;
 		void setBit(uint16_t pos, byte val);
 		byte getBit(uint16_t pos) const;
 		byte get_size(uint32_t input) const;


### PR DESCRIPTION
Time for another somewhat-big pull request! Here's the rundown (it's all good this time!):

- Added bounds check to the 'color setting by index' functions. This prevents writing a color to a digit that doesn't exist.

- Defined a per-instance FastLED controller. This way you can control things such as brightness, color balance, and show() calls on a per-group basis (i.e. there's no reason to update two groups if only one changes).

- Rewrote the color_balance math to use the built-in FastLED color temperature implementation. This way the color calibration is faster and non-destructive towards the color information. It also supports pre-existing FastLED color profiles (see [here](https://github.com/FastLED/FastLED/blob/master/examples/ColorTemperature/ColorTemperature.ino)) as well as custom calibrations (call the function with a CRGB conversion).

- Added brightness control (again using the FastLED methods).


I also split the Readme "Functions" section into "Basic Functions" and "Additional Functions", since it seems we keep adding things to the library :smile:. Feel free to rework that as you see fit.