### PR TITLE
'write' improvements, input checks, new debug function, bug fixes, and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ Inititalizes the underlying FastLED library and sets up variables like the digit
 
 Clears all displays, all lights off.
 
-**lix.write**(uint32_t **input** OR char* **input**);
+**lix.write**(int **input** OR char* **input**);
 
-    uint32_t: Clears the displays, and pushes in a multi-digit integer as in: 2016
+    int: Clears the displays, and pushes in a multi-digit integer as in: 2016
 
     char*: Clears the displays, and pushes in a char array as in: "2016". This ignores any non-numeric chars in the string, allowing you to send "12:52:47 PM" and have the displays show "12 52 47" for a clock.
 
@@ -80,7 +80,7 @@ Sets the "off" color of the digits using RGB. This is the color of all inactive 
 
 **lix.get_numdigits**();
 
-Returns the number of Lixie displays currently in use.
+Returns the number of Lixie displays currently in use as an integer.
 
 **lix.brightness**(byte **bright**);
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This library allows for easy writing to Lixie digit displays! It takes care of a
 - [Getting Started](#getting-started)
 - [Basic Functions](#basic-functions)
 - [Advanced Functions](#advanced-functions)
+- [Debug Functions](#debug-functions)
 - [Contributing](#contributing)
 - [License and credits](#license-and-credits)
 
@@ -75,12 +76,12 @@ Sets the "on" color of the digits using RGB. This is the color of an active numb
 
 Sets the "off" color of the digits using RGB. This is the color of all inactive numbers in the display. (Default: 0,0,0)
 
+**lix.show**();
+
+Force the Lixies to update with current values and colors. Called automatically after every write call.
+
 ----------
 # Advanced Functions
-
-**lix.get_numdigits**();
-
-Returns the number of Lixie displays currently in use as an integer.
 
 **lix.brightness**(byte **bright**);
 
@@ -89,6 +90,31 @@ Sets the brightness of the displays, from 0 - 255. (Default: 255)
 **lix.color_balance**(CRGB **c_adj**);
 
 Sets a color calibration for the LEDs. Supports all FastLED color temperatures, and custom temperatures in the form CRGB(r, g, b). (Default: Tungsten100W / R: 255 G: 214 B: 170)
+
+**lix.max_power**(int **volts**, int **milliamps**);
+
+Sets a software power limit for all Lixies. Displaying white at full brightness, a Lixie will draw approximately 120mA. (Default: 5V, 1000mA)
+
+**lix.get_numdigits**();
+
+Returns the number of Lixie displays currently in use, as an integer.
+
+**lix.maxed_out**(int **input**);
+
+Returns true if the input is too large to fit on the displays, false otherwise.
+
+----------
+# Debug Functions
+
+The library also includes a few debugging functions if you're having issues with your displays. These functions require that the Serial library be initialized with "Serial.begin(speed)" before they will work.
+
+**lix.print_binary**();
+
+Prints the values of the led_states array, in binary, to the serial console.
+
+**lix.print_current**();
+
+Prints the current values on the display, in integers, to the serial console.
 
 ----------
 # Contributing

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This library allows for easy writing to Lixie digit displays! It takes care of a
 - [Installation](#installation)
 - [Getting Started](#getting-started)
 - [Basic Functions](#basic-functions)
-- [Additional Functions](#additional-functions)
+- [Advanced Functions](#advanced-functions)
 - [Contributing](#contributing)
 - [License and credits](#license-and-credits)
 
@@ -76,7 +76,7 @@ Sets the "on" color of the digits using RGB. This is the color of an active numb
 Sets the "off" color of the digits using RGB. This is the color of all inactive numbers in the display. (Default: 0,0,0)
 
 ----------
-# Additional Functions
+# Advanced Functions
 
 **lix.get_numdigits**();
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@ Updated documentation (1/6/17 - dmadison)
 
 Along with all of the other changes in this pull request, I updated the keywords.txt, README.md, and changelog.md (Hi!).
 
-The keywords list was reorganized to match the header file, and I also added a few missing function keywords to the list. The README was updated with all of the new functions that have been added in the past few weeks and the 'uint32_t' datatypes were renamed as 'int' for comprehension purposes. I also changed the wording from "Additonal Funtions" to "*Advanced* Functions", and added another section for "Debug Functions".
+The keywords list was reorganized to match the header file, and I also added a few missing function keywords to the list. The README was updated with all of the new functions that have been added in the past few weeks and the 'uint32_t' datatypes were renamed as 'int' for comprehension purposes. I also changed the wording from "Additional Functions" to "*Advanced* Functions", and added another section for "Debug Functions".
 
 
 Reorganized header function order (1/6/17 - dmadison)

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,61 @@
 # LIXIE for ARDUINO CHANGE LOG:
 (Most recent at top, please!)
 
+Updated documentation (1/6/17 - dmadison)
+-----------------------------------------------------------
+
+Along with all of the other changes in this pull request, I updated the keywords.txt, README.md, and changelog.md (Hi!).
+
+The keywords list was reorganized to match the header file, and I also added a few missing function keywords to the list. The README was updated with all of the new functions that have been added in the past few weeks and the 'uint32_t' datatypes were renamed as 'int' for comprehension purposes. I also changed the wording from "Additonal Funtions" to "*Advanced* Functions", and added another section for "Debug Functions".
+
+
+Reorganized header function order (1/6/17 - dmadison)
+-----------------------------------------------------------
+
+This is an aesthetic change, but I moved around some of the functions in the header file to make a more logical order. Like functions are grouped, with more important functions higher in the list.
+
+Changed 'maxed_out' function (1/6/17 - dmadison)
+-----------------------------------------------------------
+
+I was struggling with the inaccuracy of Arduino's floats when I was rewriting the 'write' function, so I thought it was best to get rid of them here as well. The function now takes an integer rather than a float and does the calculation using the 'get_size' function. I also flipped the output, so if the value *does* 'max out' the displays the function will return *true*, rather than false.
+
+
+Added 'print_current' debug function (1/6/17 - dmadison)
+-----------------------------------------------------------
+
+While I was messing with rewriting the 'write' functions, I thought it would be useful to have a function that returned the current values of the displays, based on the led_states array. This function prints values as integers to the serial monitor in the same order they are inputted (i.e. opposite of the data order sent to the Lixies), and requires the Serial class be initialized.
+
+
+Rewrote integer version of 'write' function (1/6/17 - dmadison)
+-----------------------------------------------------------
+
+Previously the integer version of the 'write' function used a temporary character array and sprintf. I rewrote the function to work with pure integer math, which improves performance by ~10% on my setup (ignoring push_digit). It also uses less memory.
+
+
+Removed overloaded versions of the 'write' function (1/6/17 - dmadison)
+-----------------------------------------------------------
+
+Connor had added a few extra functions that overloaded the 'write' function to handle outside cases such as floats and smaller integers. This was a good idea, but in practice the overloaded methods just explicitly invoked a type conversion without doing any additional data transformation. The compiler actually catches these cases automatically, so they did nothing but add a bit of complexity to the library and confuse the compiler (e.g. "call of overloaded 'write(uint16_t&)' is ambiguous"). I removed the extra versions - smaller integers will still fit in the larger uint32_t datatype and floats are automatically type converted by the compiler.
+
+
+Added input checks to digit write functions (1/6/17 - dmadison)
+-----------------------------------------------------------
+
+The lower-level 'write_digit' and 'push_digit' functions now have input sanitization. This should prevent accidentally reading and writing outside of allocated memory.
+
+
+Cleaned up 'push_digit' function (1/6/17 - dmadison)
+-----------------------------------------------------------
+
+I added comments to make the function a bit less obscure, and I removed the redundant 'clear' call because the led_states for the first digit needs to be cleared regardless.
+
+
+Fixed get_size function bug (1/6/17 - dmadison)
+-----------------------------------------------------------
+
+Previously the function would report that any input of '0' had a size of 0. Because the '0' digit still requires one display, the function will return 1 by default and is bounded to 9 rather than 0.
+
+
 Added brightness control (1/5/17 - dmadison)
 -----------------------------------------------------------
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -11,19 +11,21 @@
 ###################################
 
 begin	KEYWORD2
-write	KEYWORD2
-push_digit	KEYWORD2
-write_digit	KEYWORD2
+clear	KEYWORD2
 show	KEYWORD2
-print_binary	KEYWORD2
-get_numdigits	KEYWORD2
-maxed_out	KEYWORD2
+write	KEYWORD2
+write_digit	KEYWORD2
+push_digit	KEYWORD2
 color	KEYWORD2
 color_off	KEYWORD2
-clear	KEYWORD2
-lix KEYWORD2
 max_power	KEYWORD2
 color_balance	KEYWORD2
+brightness  KEYWORD2
+get_numdigits	KEYWORD2
+maxed_out	KEYWORD2
+print_binary	KEYWORD2
+print_current KEYWORD2
+lix KEYWORD2
 
 ###################################
 # Constants (LITERAL1)

--- a/keywords.txt
+++ b/keywords.txt
@@ -18,9 +18,9 @@ write_digit	KEYWORD2
 push_digit	KEYWORD2
 color	KEYWORD2
 color_off	KEYWORD2
-max_power	KEYWORD2
-color_balance	KEYWORD2
 brightness  KEYWORD2
+color_balance	KEYWORD2
+max_power	KEYWORD2
 get_numdigits	KEYWORD2
 maxed_out	KEYWORD2
 print_binary	KEYWORD2

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -36,7 +36,7 @@ void Lixie::begin() {
 		colors_off[i] = CRGB(0,0,0);
 	}
 	color_balance(Tungsten100W);
-	clear();
+	clear(false);
 }
 
 void Lixie::clear(bool show_change) {

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -122,7 +122,7 @@ byte Lixie::get_size(uint32_t input) const{
 	byte places = 1;
 	while(input > 9){
 		places++;
-		input = input / 10;
+		input /= 10;
 	}
 	return places;
 }

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -208,16 +208,16 @@ void Lixie::write_digit(byte input, byte index){
 }
 
 void Lixie::push_digit(byte number) {
+	// If multiple digits, move all LED states forward one
 	if (NumDigits > 1) {
 		for (uint16_t i = NumLEDs - 1; i >= 20; i--) {
 			setBit(i,getBit(i - 20));
 		}
-		for (uint16_t i = 0; i < 20; i++) {
-			setBit(i,0);
-		}
 	}
-	else {
-		clear(false);
+ 
+	// Clear the LED states for the first digit
+	for (uint16_t i = 0; i < 20; i++) {
+		setBit(i,0);
 	}
 
 	uint16_t L1 = addresses[number];

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -227,6 +227,19 @@ void Lixie::print_binary() {
 	Serial.println();
 }
 
+void Lixie::print_current(){
+	// Reversed map of the standard addresses
+	static const uint8_t readdress[10] = {3, 9, 2, 0, 1, 6, 5, 7, 4, 8,};
+
+	for(int8_t i = NumDigits - 1; i >= 0; i--){
+		for(uint8_t j = 0; j < 10; j++){
+			if(getBit(i*20 + j))
+				Serial.print(readdress[j]);
+		}
+	}
+	Serial.println();
+}
+
 uint8_t Lixie::get_numdigits() const{
 	return NumDigits;
 }

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -209,7 +209,7 @@ void Lixie::push_digit(byte number) {
 	setBit(L2,1);
 }
 
-void Lixie::print_binary() {
+void Lixie::print_binary() const{
 	for (uint16_t i = 0; i < NumLEDs; i++) {
 		Serial.print(getBit(i));
 		if ((i + 1) % 20 == 0 && i != 0) {
@@ -219,7 +219,7 @@ void Lixie::print_binary() {
 	Serial.println();
 }
 
-void Lixie::print_current(){
+void Lixie::print_current() const{
 	// Reversed map of the standard addresses
 	static const uint8_t readdress[10] = {3, 9, 2, 0, 1, 6, 5, 7, 4, 8,};
 
@@ -236,7 +236,7 @@ uint8_t Lixie::get_numdigits() const{
 	return NumDigits;
 }
 
-bool Lixie::maxed_out(uint32_t input){
+bool Lixie::maxed_out(uint32_t input) const{
 	if(get_size(input) > NumDigits) // If input > number that can be displayed
 		return true;
 	else

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -175,7 +175,7 @@ void Lixie::write(double input){
 }
 
 void Lixie::write_digit(byte input, byte index){
-	if(input > 9) return;
+	if(input > 9 || index >= NumDigits) return;
   
 	uint16_t start = (index*20);
 

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -237,12 +237,10 @@ uint8_t Lixie::get_numdigits() const{
 }
 
 bool Lixie::maxed_out(uint32_t input){
-	if(get_size(input) > NumDigits){ // If input > number that can be displayed
-		return false;
-	}
-	else{
+	if(get_size(input) > NumDigits) // If input > number that can be displayed
 		return true;
-	}
+	else
+		return false;
 }
 
 void Lixie::build_controller(uint8_t DataPin){

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -166,23 +166,6 @@ void Lixie::write(uint32_t input){
 	show();
 }
 
-void Lixie::write(int input){
-	write(uint32_t(input));
-}
-
-
-void Lixie::write(long input){
-	write(uint32_t(input));
-}
-
-void Lixie::write(int8_t input){
-	write(uint32_t(input));
-}
-
-void Lixie::write(byte input){
-	write(uint32_t(input));
-}
-
 void Lixie::write(float input){
 	write(uint32_t(input));
 }

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -192,6 +192,8 @@ void Lixie::write(double input){
 }
 
 void Lixie::write_digit(byte input, byte index){
+	if(input > 9) return;
+  
 	uint16_t start = (index*20);
 
 	for(uint16_t i = start; i < start+20; i++){

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -169,14 +169,6 @@ void Lixie::write(uint32_t input){
 	show();
 }
 
-void Lixie::write(float input){
-	write(uint32_t(input));
-}
-
-void Lixie::write(double input){
-	write(uint32_t(input));
-}
-
 void Lixie::write_digit(byte input, byte index){
 	if(input > 9 || index >= NumDigits) return;
   

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -208,6 +208,8 @@ void Lixie::write_digit(byte input, byte index){
 }
 
 void Lixie::push_digit(byte number) {
+	if(number > 9) return;
+
 	// If multiple digits, move all LED states forward one
 	if (NumDigits > 1) {
 		for (uint16_t i = NumLEDs - 1; i >= 20; i--) {

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -119,8 +119,8 @@ void Lixie::color_off(CRGB c, byte index){
 }
 
 byte Lixie::get_size(uint32_t input) const{
-	byte places = 0;
-	while(input > 0){
+	byte places = 1;
+	while(input > 9){
 		places++;
 		input = input / 10;
 	}

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -152,17 +152,20 @@ void Lixie::write(char* input){
 }
 
 void Lixie::write(uint32_t input){
-	char t[20] = "";
-	sprintf(t,"%lu",input);
+	uint32_t nPlace = 1;
+
 	clear(false);
-	if(input != 0){
-		for(byte i = 0; i < get_size(input); i++){
-			push_digit(char_to_number(t[i]));
-		}
+
+	// Powers of 10 while avoiding floating point math
+	for(uint8_t i = 1; i < get_size(input); i++){
+		nPlace *= 10;
 	}
-	else{
-		push_digit(0);
+
+	for(nPlace; nPlace > 0; nPlace /= 10){
+		push_digit(input / nPlace);
+		if(nPlace > 1) input = (input % nPlace);
 	}
+
 	show();
 }
 

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -236,8 +236,8 @@ uint8_t Lixie::get_numdigits() const{
 	return NumDigits;
 }
 
-bool Lixie::maxed_out(float input){
-	if(input >= pow(10,NumDigits)){ // If input > number that can be displayed
+bool Lixie::maxed_out(uint32_t input){
+	if(get_size(input) > NumDigits){ // If input > number that can be displayed
 		return false;
 	}
 	else{

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -29,6 +29,7 @@ class Lixie{
 
 		void show();
 		void print_binary();
+		void print_current();
 		uint8_t get_numdigits() const;
 		bool maxed_out(float input);
 

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -14,36 +14,36 @@ class Lixie{
 	public:
 		Lixie(uint8_t pin, uint8_t nDigits);
 		void begin();
+   
 		void clear(bool show_change = true);
-
+		void show();
 		void write(uint32_t input);
 		void write(char* input);
-	
-		void push_digit(byte number);
+    
 		void write_digit(byte input, byte index);
-	
-		void max_power(byte volts, uint16_t milliamps);
-
-		void show();
-		void print_binary();
-		void print_current();
-		uint8_t get_numdigits() const;
-		bool maxed_out(float input);
-
+		void push_digit(byte number);
+    
 		void color(byte r, byte g, byte b);
 		void color(CRGB c);
-
 		void color(byte r, byte g, byte b, byte index);
 		void color(CRGB c, byte index);
 
 		void color_off(byte r, byte g, byte b);
 		void color_off(CRGB c);
-
 		void color_off(byte r, byte g, byte b, byte index);
 		void color_off(CRGB c, byte index);
-		
+	
+		void max_power(byte volts, uint16_t milliamps);
+
 		void color_balance(CRGB c_adj);
 		void brightness(byte bright);
+		
+		uint8_t get_numdigits() const;
+		bool maxed_out(float input);
+
+		// Debug Functions
+		void print_binary();
+		void print_current();
 
 	private:
 		static constexpr byte addresses[10] = {3, 4, 2, 0, 8, 6, 5, 7, 9, 1};

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -32,11 +32,11 @@ class Lixie{
 		void color_off(CRGB c);
 		void color_off(byte r, byte g, byte b, byte index);
 		void color_off(CRGB c, byte index);
-	
-		void max_power(byte volts, uint16_t milliamps);
 
 		void brightness(byte bright);
 		void color_balance(CRGB c_adj);
+
+		void max_power(byte volts, uint16_t milliamps);
 	
 		uint8_t get_numdigits() const;
 		bool maxed_out(uint32_t input);

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -19,10 +19,6 @@ class Lixie{
 		void write(uint32_t input);
 		void write(char* input);
 	
-		void write(int input);
-		void write(long input);
-		void write(int8_t input);
-		void write(byte input);
 		void write(float input);
 		void write(double input);
 	

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -19,9 +19,6 @@ class Lixie{
 		void write(uint32_t input);
 		void write(char* input);
 	
-		void write(float input);
-		void write(double input);
-	
 		void push_digit(byte number);
 		void write_digit(byte input, byte index);
 	

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -35,9 +35,9 @@ class Lixie{
 	
 		void max_power(byte volts, uint16_t milliamps);
 
-		void color_balance(CRGB c_adj);
 		void brightness(byte bright);
-		
+		void color_balance(CRGB c_adj);
+	
 		uint8_t get_numdigits() const;
 		bool maxed_out(uint32_t input);
 

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -39,7 +39,7 @@ class Lixie{
 		void brightness(byte bright);
 		
 		uint8_t get_numdigits() const;
-		bool maxed_out(float input);
+		bool maxed_out(uint32_t input);
 
 		// Debug Functions
 		void print_binary();

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -39,11 +39,11 @@ class Lixie{
 		void max_power(byte volts, uint16_t milliamps);
 	
 		uint8_t get_numdigits() const;
-		bool maxed_out(uint32_t input);
+		bool maxed_out(uint32_t input) const;
 
 		// Debug Functions
-		void print_binary();
-		void print_current();
+		void print_binary() const;
+		void print_current() const;
 
 	private:
 		static constexpr byte addresses[10] = {3, 4, 2, 0, 8, 6, 5, 7, 9, 1};


### PR DESCRIPTION
Last **big** pull request, promise! Need to get back to work on my own projects.

Changes:

- **Fixed 'get_size' bug**: 
Previously the function would report that any input of '0' had a size of 0. Because the '0' digit still requires one display, the function will now return 1 by default and is bounded to 9 rather than 0.

- **Cleaned 'push_digit' function**:
I added comments to make the function a bit less obscure, and I removed the redundant 'clear' call because the led_states for the first digit needs to be cleared regardless.

- **Added input checks to digit write functions**:
The lower-level 'write_digit' and 'push_digit' functions now have input sanitization. This should prevent accidentally reading and writing outside of allocated memory.

- **Removed overloaded versions of the 'write' function**:
These were actually causing more problems than anything else. Because *almost* everything was defined, a fringe case (uint16_t) was causing compiler issues. A number of these overloaded functions were redundant (uint8_t, byte, int, and long are all encapsulated in uint32_t with no type conversion at all), and the floats are automatically converted to uint32_t by the compiler. Removing all of the excess functions makes the library smaller and less complex, and fixes the compiler issue.
   
   It may make sense to add the float function(s) back in the future with a function to save the digits past the decimal, but that's a separate discussion.

- **Rewrote the uint32_t version of the 'write' function to use integer math**:
This is what I was originally working on before I got carried away. Previously the integer version of the 'write' function used a temporary character array and sprintf. I rewrote the function to work with pure integer math, which improves performance by ~10% on my setup (ignoring push_digit). It also uses less memory.

- **Added 'print_current' debug function**:
While I was messing with rewriting the 'write' functions, I thought it would be useful to have a function that returned the current values of the displays, based on the led_states array. This function prints values as integers to the serial monitor in the same order they are inputted (i.e. opposite of the data order sent to the Lixies), and requires the Serial class be initialized.

- **Changed 'maxed_out' function to use integer math**:
I was struggling with the inaccuracy of Arduino's floats when I was rewriting the 'write' function, so I thought it was best to get rid of them here as well. The function now takes an integer rather than a float and does the calculation using the 'get_size' function. I also flipped the output, so if the value *does* 'max out' the displays the function will return *true*, rather than false.

- **Reorganized header function order**:
This is an aesthetic change, but I moved around some of the functions in the header file to make a more logical order. Like functions are grouped, with more important functions higher in the list.

- **Updated documentation**:
Along with all of the other changes in this pull request, I updated the keywords.txt, README.md, and changelog.md.

   The keywords list was reorganized to match the header file, and I also added a few missing function keywords to the list. The README was updated with all of the new functions that have been added in the past few weeks and the 'uint32_t' datatypes were renamed as 'int' for comprehension purposes. I also changed the wording from "Additional Functions" to "*Advanced* Functions", and added another section for "Debug Functions".


As always -- all of these changes work on my end, but please check a clone against the actual hardware to make sure it works as-intended.