### PR TITLE
'clear' function now uses memset (& misc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This library allows for easy writing to Lixie digit displays! It takes care of a
 - [Basic Functions](#basic-functions)
 - [Advanced Functions](#advanced-functions)
 - [Debug Functions](#debug-functions)
+- [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
 - [License and credits](#license-and-credits)
 
@@ -115,6 +116,13 @@ Prints the values of the led_states array, in binary, to the serial console.
 **lix.print_current**();
 
 Prints the current values on the display, in integers, to the serial console.
+
+----------
+# Troubleshooting
+
+At the moment the library uses dynamic allocation for the LED arrays, which is not reported as allocated memory by the compiler. If your microcontroller is doing strange things, the first thing to check is that you have at least 70 bytes of dynamic memory available per Lixie digit.
+
+If you've discovered a bug in the library, please create an issue on the Github repository so it can be fixed!
 
 ----------
 # Contributing

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Returns the number of Lixie displays currently in use, as an integer.
 
 Returns true if the input is too large to fit on the displays, false otherwise.
 
+**lix.get_leds**();
+
+Returns a pointer to the CRGB array that holds the color values sent to the displays. The library's *show()* function overwrites the values in this array, so call *FastLED.show()* to see any changes.
+
 ----------
 # Debug Functions
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,22 @@
 # LIXIE for ARDUINO CHANGE LOG:
 (Most recent at top, please!)
 
+Misc. Updates (1/8/17 - dmadison)
+-----------------------------------------------------------
+
+I tweaked the ESP8266-specific code Connor just added so it's mutually exclusive with the AVR (Arduino) architecture, which should prevent the program from trying to create duplicate FastLED controllers. There was also an 'else' missing in the AVR if statement ladder which was fixed.
+
+I also added a 'LEDsPerDigit' constant set to 20, to replace all of the scattered '20' values around the library. Should make the code more readable. 
+
+Lastly, I updated the README to include a 'Troubleshooting' section and a line about needing to leave a little dynamic memory for the Lixie arrays.
+
+'Clear' function now uses memset (1/8/17 - dmadison)
+-----------------------------------------------------------
+
+I rewrote the 'clear' function to use 'memset' rather than 'setBit'. That means rather than going bit by bit finding the correct place in the led_state array and then performing a *single* bitWrite, it simply rewrites the entire chunk of memory at once. On my rig it's another 10% speed increase!
+
+It may make sense to eventually call 'memset' for the times the library clears single digits, but in the current implementation the digits share bytes in the array so it's not possible.
+
 Fixed ESP8266 compilation issue (1/7/17 - Connor Nishijima)
 -----------------------------------------------------------
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,11 @@
 # LIXIE for ARDUINO CHANGE LOG:
 (Most recent at top, please!)
 
+Added 'get_leds' function (1/8/17 - dmadison)
+-----------------------------------------------------------
+
+Added a simple function that returns a pointer to the LED array. This allows the user to edit the data sent to the LEDs directly if they wish.
+
 Misc. Updates (1/8/17 - dmadison)
 -----------------------------------------------------------
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,11 @@ Misc. Updates (1/8/17 - dmadison)
 
 I tweaked the ESP8266-specific code Connor just added so it's mutually exclusive with the AVR (Arduino) architecture, which should prevent the program from trying to create duplicate FastLED controllers. There was also an 'else' missing in the AVR if statement ladder which was fixed.
 
-I also added a 'LEDsPerDigit' constant set to 20, to replace all of the scattered '20' values around the library. Should make the code more readable. 
+At the same time I removed all of the brackets from the build_controller case ladder. No reason for them to be there, and it makes the code neater. The 'addresses' array was also capitalzied to signify it is constant.
+
+I moved the LED defines (LED_TYPE and COLOR_ORDER) to the header and added guards to prevent redefines.
+
+I also added a 'LEDsPerDigit' constant set to 20, to replace all of the scattered '20' values around the library. Should make the code more readable.
 
 Lastly, I updated the README to include a 'Troubleshooting' section and a line about needing to leave a little dynamic memory for the Lixie arrays.
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -23,6 +23,7 @@ color_balance	KEYWORD2
 max_power	KEYWORD2
 get_numdigits	KEYWORD2
 maxed_out	KEYWORD2
+get_leds  KEYWORD2
 print_binary	KEYWORD2
 print_current KEYWORD2
 lix KEYWORD2

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -8,7 +8,7 @@ Released under the GPLv3 license.
 
 constexpr byte Lixie::addresses[];
 
-Lixie::Lixie(const uint8_t pin, uint8_t nDigits):NumDigits(nDigits), NumLEDs(nDigits * 20){
+Lixie::Lixie(const uint8_t pin, uint8_t nDigits):NumDigits(nDigits), NumLEDs(nDigits * LEDsPerDigit){
 	leds = new CRGB[NumLEDs];
 	led_states = new byte[NumDigits * 3]; // 24 bits for 20 LED states
 	colors = new CRGB[NumDigits];
@@ -46,9 +46,9 @@ void Lixie::clear(bool show_change) {
 void Lixie::show(){
 	for(uint16_t i = 0; i < NumLEDs; i++){
 		if(getBit(i) == 1)
-			leds[i] = colors[i/20];
+			leds[i] = colors[i/LEDsPerDigit];
 		else
-			leds[i] = colors_off[i/20];
+			leds[i] = colors_off[i/LEDsPerDigit];
 	}
 	controller->showLeds(bright);
 }
@@ -167,9 +167,9 @@ void Lixie::write(uint32_t input){
 void Lixie::write_digit(byte input, byte index){
 	if(input > 9 || index >= NumDigits) return;
   
-	uint16_t start = (index*20);
+	uint16_t start = (index*LEDsPerDigit);
 
-	for(uint16_t i = start; i < start+20; i++){
+	for(uint16_t i = start; i < start+LEDsPerDigit; i++){
 		setBit(i,0);
 	}
 
@@ -187,13 +187,13 @@ void Lixie::push_digit(byte number) {
 
 	// If multiple digits, move all LED states forward one
 	if (NumDigits > 1) {
-		for (uint16_t i = NumLEDs - 1; i >= 20; i--) {
-			setBit(i,getBit(i - 20));
+		for (uint16_t i = NumLEDs - 1; i >= LEDsPerDigit; i--) {
+			setBit(i,getBit(i - LEDsPerDigit));
 		}
 	}
  
 	// Clear the LED states for the first digit
-	for (uint16_t i = 0; i < 20; i++) {
+	for (uint16_t i = 0; i < LEDsPerDigit; i++) {
 		setBit(i,0);
 	}
 
@@ -207,7 +207,7 @@ void Lixie::push_digit(byte number) {
 void Lixie::print_binary() const{
 	for (uint16_t i = 0; i < NumLEDs; i++) {
 		Serial.print(getBit(i));
-		if ((i + 1) % 20 == 0 && i != 0) {
+		if ((i + 1) % LEDsPerDigit == 0 && i != 0) {
 			Serial.print('\t');
 		}
 	}
@@ -220,7 +220,7 @@ void Lixie::print_current() const{
 
 	for(int8_t i = NumDigits - 1; i >= 0; i--){
 		for(uint8_t j = 0; j < 10; j++){
-			if(getBit(i*20 + j))
+			if(getBit(i*LEDsPerDigit + j))
 				Serial.print(readdress[j]);
 		}
 	}

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -37,9 +37,7 @@ void Lixie::begin() {
 }
 
 void Lixie::clear(bool show_change) {
-	for (uint16_t i = 0; i < NumLEDs; i++) {
-		setBit(i,0);
-	}
+	memset(led_states, 0, NumDigits * 3);
 	if(show_change == true){
 		show();
 	}

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -273,8 +273,7 @@ void Lixie::build_controller(const uint8_t pin){
 			controller = &FastLED.addLeds<LED_TYPE, 12, COLOR_ORDER>(leds, NumLEDs);
 		else if (pin == 13)
 			controller = &FastLED.addLeds<LED_TYPE, 13, COLOR_ORDER>(leds, NumLEDs);
-	#endif
-	#ifdef ESP8266
+	#elif ESP8266
 		if (pin == 0)
 			controller = &FastLED.addLeds<LED_TYPE, 0, COLOR_ORDER>(leds, NumLEDs);
 		else if (pin == 2)

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -6,9 +6,6 @@ Released under the GPLv3 license.
 
 #include "Lixie.h"
 
-#define LED_TYPE    WS2812B
-#define COLOR_ORDER GRB
-
 constexpr byte Lixie::addresses[];
 
 Lixie::Lixie(const uint8_t pin, uint8_t nDigits):NumDigits(nDigits), NumLEDs(nDigits * 20){

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -238,6 +238,10 @@ bool Lixie::maxed_out(uint32_t input) const{
 		return false;
 }
 
+CRGB* Lixie::get_leds() const{
+	return leds;
+}
+
 void Lixie::build_controller(const uint8_t pin){
 	#ifdef __AVR__
 		if (pin == 0)

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -248,7 +248,7 @@ void Lixie::build_controller(const uint8_t pin){
 		if (pin == 0){
 			controller = &FastLED.addLeds<LED_TYPE, 0, COLOR_ORDER>(leds, NumLEDs);
 		}
-		if (pin == 1){
+		else if (pin == 1){
 			controller = &FastLED.addLeds<LED_TYPE, 1, COLOR_ORDER>(leds, NumLEDs);
 		}
 		else if (pin == 2){

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -245,65 +245,46 @@ bool Lixie::maxed_out(uint32_t input) const{
 
 void Lixie::build_controller(const uint8_t pin){
 	#ifdef __AVR__
-		if (pin == 0){
+		if (pin == 0)
 			controller = &FastLED.addLeds<LED_TYPE, 0, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 1){
+		else if (pin == 1)
 			controller = &FastLED.addLeds<LED_TYPE, 1, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 2){
+		else if (pin == 2)
 			controller = &FastLED.addLeds<LED_TYPE, 2, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 3){
+		else if (pin == 3)
 			controller = &FastLED.addLeds<LED_TYPE, 3, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 4){
+		else if (pin == 4)
 			controller = &FastLED.addLeds<LED_TYPE, 4, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 5){
+		else if (pin == 5)
 			controller = &FastLED.addLeds<LED_TYPE, 5, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 6){
+		else if (pin == 6)
 			controller = &FastLED.addLeds<LED_TYPE, 6, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 7){
+		else if (pin == 7)
 			controller = &FastLED.addLeds<LED_TYPE, 7, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 8){
+		else if (pin == 8)
 			controller = &FastLED.addLeds<LED_TYPE, 8, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 9){
+		else if (pin == 9)
 			controller = &FastLED.addLeds<LED_TYPE, 9, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 10){
+		else if (pin == 10)
 			controller = &FastLED.addLeds<LED_TYPE, 10, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 11){
+		else if (pin == 11)
 			controller = &FastLED.addLeds<LED_TYPE, 11, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 12){
+		else if (pin == 12)
 			controller = &FastLED.addLeds<LED_TYPE, 12, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 13){
+		else if (pin == 13)
 			controller = &FastLED.addLeds<LED_TYPE, 13, COLOR_ORDER>(leds, NumLEDs);
-		}
 	#endif
 	#ifdef ESP8266
-		if (pin == 0){
+		if (pin == 0)
 			controller = &FastLED.addLeds<LED_TYPE, 0, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 2){
+		else if (pin == 2)
 			controller = &FastLED.addLeds<LED_TYPE, 2, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 4){
+		else if (pin == 4)
 			controller = &FastLED.addLeds<LED_TYPE, 4, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 12){
+		else if (pin == 12)
 			controller = &FastLED.addLeds<LED_TYPE, 12, COLOR_ORDER>(leds, NumLEDs);
-		}
-		else if (pin == 13){
+		else if (pin == 13)
 			controller = &FastLED.addLeds<LED_TYPE, 13, COLOR_ORDER>(leds, NumLEDs);
-		}
 	#endif
 }
 

--- a/src/Lixie.cpp
+++ b/src/Lixie.cpp
@@ -6,7 +6,7 @@ Released under the GPLv3 license.
 
 #include "Lixie.h"
 
-constexpr byte Lixie::addresses[];
+constexpr byte Lixie::Addresses[];
 
 Lixie::Lixie(const uint8_t pin, uint8_t nDigits):NumDigits(nDigits), NumLEDs(nDigits * LEDsPerDigit){
 	leds = new CRGB[NumLEDs];
@@ -173,8 +173,8 @@ void Lixie::write_digit(byte input, byte index){
 		setBit(i,0);
 	}
 
-	uint16_t L1 = start+addresses[input];
-	uint16_t L2 = start+addresses[input] + 10;
+	uint16_t L1 = start+Addresses[input];
+	uint16_t L2 = start+Addresses[input] + 10;
 
 	setBit(L1,1);
 	setBit(L2,1);
@@ -197,8 +197,8 @@ void Lixie::push_digit(byte number) {
 		setBit(i,0);
 	}
 
-	uint16_t L1 = addresses[number];
-	uint16_t L2 = addresses[number] + 10;
+	uint16_t L1 = Addresses[number];
+	uint16_t L2 = Addresses[number] + 10;
 
 	setBit(L1,1);
 	setBit(L2,1);

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -54,7 +54,7 @@ class Lixie{
 		void print_current() const;
 
 	private:
-		static constexpr byte addresses[10] = {3, 4, 2, 0, 8, 6, 5, 7, 9, 1};
+		static constexpr byte Addresses[10] = {3, 4, 2, 0, 8, 6, 5, 7, 9, 1};
 		const static uint8_t LEDsPerDigit = 20;
 		const uint8_t NumDigits;
 		const uint16_t NumLEDs;

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -10,6 +10,14 @@ Released under the GPLv3 license.
 #include "Arduino.h"
 #include "FastLED.h"
 
+#ifndef LED_TYPE
+  #define LED_TYPE WS2812B
+#endif
+
+#ifndef COLOR_ORDER
+  #define COLOR_ORDER GRB
+#endif
+
 class Lixie{
 	public:
 		Lixie(const uint8_t pin, uint8_t nDigits);

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -55,6 +55,7 @@ class Lixie{
 
 	private:
 		static constexpr byte addresses[10] = {3, 4, 2, 0, 8, 6, 5, 7, 9, 1};
+		const static uint8_t LEDsPerDigit = 20;
 		const uint8_t NumDigits;
 		const uint16_t NumLEDs;
 		CRGB *leds;

--- a/src/Lixie.h
+++ b/src/Lixie.h
@@ -49,6 +49,8 @@ class Lixie{
 		uint8_t get_numdigits() const;
 		bool maxed_out(uint32_t input) const;
 
+		CRGB* get_leds() const;
+
 		// Debug Functions
 		void print_binary() const;
 		void print_current() const;


### PR DESCRIPTION
Some small changes:

- **Clear' function now uses memset**:
I rewrote the 'clear' function to use 'memset' rather than a loop which called 'setBit'. That means rather than going bit by bit finding the correct place in the led_state array and then performing a *single* bitWrite, it simply rewrites the entire chunk of memory at once. On my rig it's another 10% speed increase!

  It may make sense to eventually call 'memset' for the times the library clears single digits, but in the current implementation the digits share bytes in the led_states array so it's not possible.

- **Made ESP8266 build_controller case mutually exclusive**:
I switched the separate 'ifdef' to an 'elif' combined with the AVR declaration. This should prevent the program from attempting to build two identical controllers if both system macros exist (e.g. using an ESP8266 add-on with an Arduino).

- **Simplified build_controller syntax**:
Removed the brackets from all cases. No functional change, just simpler code.

- **Capitalized 'addresses' array**:
Style tweak. Capitalization to signify that it's a constant.

- **Moved LED defines to header**:
Makes more sense for them to be in the header. I also added guards to prevent redefines.

- **Created 'LEDsPerDigit' constant**:
I added a 'LEDsPerDigit' constant set to 20, to replace all of the scattered '20' values around the library. Should make the code more readable.

- **Added 'Troubleshooting' section to README**:
I updated the README to include a 'Troubleshooting' section and a line about needing to leave a little dynamic memory for the Lixie arrays.

- **Added 'get_leds' function**:
Basic function that returns a pointer to the leds array. Useful if the user wants to modify the color data sent to the displays.

With that, I'm running out of changes to make! Which can only be a good sign :satisfied:.

Everything compiles on my setup, but you should check against your ESP8266 test bench to make sure the 'build_controller' code specifically still works as-intended.